### PR TITLE
Fix metrics-api uml syntax

### DIFF
--- a/uml/metrics-api.puml
+++ b/uml/metrics-api.puml
@@ -47,22 +47,22 @@ abstract class MetricRegistry {
 Counting -[hidden]> Metric
 Sampling -[hidden]> Metric
 
-interface Metered -up-|> Metric
-interface Metered -up-|> Counting
+'interface Metered -up-|> Metric
+'interface Metered -up-|> Counting
 
-interface Gauge -up--|> Metric
+'interface Gauge -up--|> Metric
 
-interface Counter -up--|> Metric
-interface Counter -up-|> Counting
+'interface Counter -up--|> Metric
+'interface Counter -up-|> Counting
 
-interface Histogram -up--|> Metric
-interface Histogram -up-|> Counting
-interface Histogram -up-|> Sampling
-interface Meter -up-|> Metered
-interface Timer -up-|> Metered
-interface Timer -up-|> Sampling
+'interface Histogram -up--|> Metric
+'interface Histogram -up-|> Counting
+'interface Histogram -up-|> Sampling
+'interface Meter -up-|> Metered
+'interface Timer -up-|> Metered
+'interface Timer -up-|> Sampling
 
-interface MetricSet -left-|> Metric
+'interface MetricSet -left-|> Metric
 
 'interface DynamicMetricSet -up-|> Metric
 


### PR DESCRIPTION
Fix minor uml syntax problem

before:
![image](https://user-images.githubusercontent.com/1197310/55477831-ac50f200-564c-11e9-87d4-97b0eefe3946.png)
after:
![image](https://user-images.githubusercontent.com/1197310/55478047-35682900-564d-11e9-930c-6f556a8df1de.png)

